### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ team2 = [Rating.new(1500, 1500/3), Rating.new(1400, 1400/3)]
 team3 = [Rating.new(1300, 1300/3), Rating.new(1200, 1200/3)]
 
 new_ratings =
-  FactorGraph.calculate_ratings([team1, team2, team3], [1, 2, 3], %{team_performance_addaptive: false})
+  FactorGraph.calculate_ratings([team1, team2, team3], [1, 2, 3], %{team_performance_adaptive: false})
 new_ratings =
-  FactorGraph.calculate_ratings([team1, team2, team3], %{team_performance_addaptive: false})
+  FactorGraph.calculate_ratings([team1, team2, team3], %{team_performance_adaptive: false})
 
 new_ratings =
-  FactorGraph.calculate_ratings([team1, team2, [1, 2, 1], %{team_performance_addaptive: false})
+  FactorGraph.calculate_ratings([team1, team2, [1, 2, 1], %{team_performance_adaptive: false})
 
 team_rating = FactorGraph.team_rating(team1)
 ```

--- a/lib/trueskill/factor_graph.ex
+++ b/lib/trueskill/factor_graph.ex
@@ -6,7 +6,7 @@ defmodule Trueskill.FactorGraph do
   def team_rating(team, options \\ %{}) do
     skills = Trueskill.Factors.PriorFactor.down([team])
     performances = Trueskill.Factors.LikelihoodFactor.down(skills)
-    team_performance_options = Map.take(options, [:team_performance_addaptive])
+    team_performance_options = Map.take(options, [:team_performance_adaptive])
     Trueskill.Factors.SumFactor.down(performances, team_performance_options)
       |> Enum.map(fn(x) -> Trueskill.Variable.to_rating(x) end)
       |> List.first
@@ -30,7 +30,7 @@ defmodule Trueskill.FactorGraph do
 
     skills = Trueskill.Factors.PriorFactor.down(sorted_teams)
     performances = Trueskill.Factors.LikelihoodFactor.down(skills)
-    team_performance_options = Map.take(options, [:team_performance_addaptive])
+    team_performance_options = Map.take(options, [:team_performance_adaptive])
     team_performances = Trueskill.Factors.SumFactor.down(performances, team_performance_options)
     margin = draw_margin(draw_portability, beta, Enum.count(teams))
     new_team_performances = Trueskill.Factors.IteratedFactor.iterate(team_performances, sorted_ranks, margin)

--- a/lib/trueskill/factors/sum_factor.ex
+++ b/lib/trueskill/factors/sum_factor.ex
@@ -3,7 +3,7 @@ defmodule Trueskill.Factors.SumFactor do
   alias Trueskill.Gaussian.Distribution, as: Gaussian
 
   def down(performances, options) do
-    addaptive = options[:team_performance_addaptive]
+    adaptive = options[:team_performance_adaptive]
     Enum.map(performances, fn(performance) ->
       input_values = Enum.map(performance, fn(x) ->
         x.value
@@ -15,29 +15,29 @@ defmodule Trueskill.Factors.SumFactor do
         end
       end)
       coefficients = Enum.map(performance, fn(_) -> 1 end)
-        |> adjust_coefficients(addaptive)
+        |> adjust_coefficients(adaptive)
       [new_value, new_message] = sum(Gaussian.new, Gaussian.new, input_values, input_messages, coefficients)
       %Trueskill.Variable{value: new_value, messages: %{sum: new_message, diff: Gaussian.new}}
     end)
   end
 
   def up(team_performances, performances, options) do
-    addaptive = options[:team_performance_addaptive]
+    adaptive = options[:team_performance_adaptive]
     Enum.zip(team_performances, performances)
       |> Enum.map(fn({team_performance, player_performances}) ->
-        update_player_performance(team_performance, player_performances, addaptive)
+        update_player_performance(team_performance, player_performances, adaptive)
       end)
   end
 
-  defp update_player_performance(team_performance, player_performances, addaptive) do
+  defp update_player_performance(team_performance, player_performances, adaptive) do
     Enum.with_index(player_performances)
       |> Enum.map(fn({player_performance, idx}) ->
         rest_player_performances = List.delete_at(player_performances, idx)
-        input_values = [team_performance.value|Enum.map(rest_player_performances, fn(x) -> 
+        input_values = [team_performance.value|Enum.map(rest_player_performances, fn(x) ->
           x.value end)]
-        input_messages = [team_performance.messages.sum|Enum.map(rest_player_performances, fn(x) -> 
+        input_messages = [team_performance.messages.sum|Enum.map(rest_player_performances, fn(x) ->
           x.messages.sum end)]
-        v =  case addaptive do
+        v =  case adaptive do
           true -> 1
           false -> Enum.count(player_performances)
         end

--- a/lib/trueskill/factors/sum_factor_base.ex
+++ b/lib/trueskill/factors/sum_factor_base.ex
@@ -1,10 +1,10 @@
 defmodule Trueskill.Factors.SumFactorBase do
   alias Trueskill.Gaussian.Distribution, as: Gaussian
 
-  def adjust_coefficients(coefficients, addaptive) do
+  def adjust_coefficients(coefficients, adaptive) do
     input_size = Enum.count(coefficients)
     Enum.map(coefficients, fn(x) ->
-      case addaptive do
+      case adaptive do
         false -> x / input_size
         true  -> x
       end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Trueskill.Mixfile do
 
   def project do
     [app: :trueskill,
-     version: "0.1.0",
+     version: "0.1.1",
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/spec/trueskill/factor_graph_spec.exs
+++ b/spec/trueskill/factor_graph_spec.exs
@@ -10,7 +10,7 @@ defmodule Trueskill.FactorGraphSpec do
 
     context "when team1 won" do
       it do
-        [[u1,u2,u3,u4],[u5,u6,u7]] = FactorGraph.calculate_ratings([team1, team2], [1, 2], %{team_performance_addaptive: false})
+        [[u1,u2,u3,u4],[u5,u6,u7]] = FactorGraph.calculate_ratings([team1, team2], [1, 2], %{team_performance_adaptive: false})
         IO.inspect u1
         IO.inspect u5
         expect(u1.mean).to be :>, 2000.0
@@ -24,7 +24,7 @@ defmodule Trueskill.FactorGraphSpec do
     end
     context "with draw" do
       it do
-        [[u1,u2,u3,u4],[u5,u6,u7]] = FactorGraph.calculate_ratings([team1, team2], [1, 1], %{team_performance_addaptive: false})
+        [[u1,u2,u3,u4],[u5,u6,u7]] = FactorGraph.calculate_ratings([team1, team2], [1, 1], %{team_performance_adaptive: false})
         expect(u1.mean).to be :>, 2000.0
         expect(u2.mean).to be :>, 1600.0
         expect(u3.mean).to be :>, 1200.0
@@ -36,7 +36,7 @@ defmodule Trueskill.FactorGraphSpec do
     end
     context "when team2 won" do
       it do
-        [[u5,u6,u7],[u1,u2,u3,u4]] = FactorGraph.calculate_ratings([team2, team1], [1, 2], %{team_performance_addaptive: false})
+        [[u5,u6,u7],[u1,u2,u3,u4]] = FactorGraph.calculate_ratings([team2, team1], [1, 2], %{team_performance_adaptive: false})
         expect(u1.mean).to be :<, 2000.0
         expect(u2.mean).to be :<, 1600.0
         expect(u3.mean).to be :<, 1200.0


### PR DESCRIPTION
- fixing typos 
  - `team_performance_addaptive` -> `team_performance_adaptive`
  - `addaptive` -> `adaptive`
- increments version to 0.1.1 due to compatibility issue

test results are below

```
        23 examples, 0 failures, 2 pending

        Finished in 0.2 seconds (0.17s on load, 0.02s on specs)
```
